### PR TITLE
Peasy-UI: Fix tsc types can't resolve 'when respecting package.json "exports"'

### DIFF
--- a/packages/peasy-ui/package.json
+++ b/packages/peasy-ui/package.json
@@ -4,10 +4,16 @@
   "main": "./dist/esm/index.mjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "require": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/cjs/index.cjs"
+    },
+    "import": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.mjs"
+    }
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "UNLICENSED",
   "description": "An easy peasy UI binding library.",
   "author": "Jürgen Wenzel",


### PR DESCRIPTION
Fix Error:
```
...@peasy-lib/peasy-ui/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@peasy-lib/peasy-ui' library may need to update its package.json or typings.
```
![image](https://github.com/user-attachments/assets/72e9639a-5c90-4adb-9e8d-90e183b2c126)


I resolved this thanks to this stack overflow answer: https://stackoverflow.com/a/77566206
Which shows that each export target has their own "types" property. Though both targets use the same types, it seems that `tsc` might get confused when trying to follow the exports without specifying the types.